### PR TITLE
Evan contract updates

### DIFF
--- a/contracts/gamefactory.sol
+++ b/contracts/gamefactory.sol
@@ -19,6 +19,7 @@ contract GameFactory is Ownable {
         address white;
         address black;
 
+        bool turn;  //false for white true for black
         string position;
     }
 
@@ -28,11 +29,11 @@ contract GameFactory is Ownable {
     mapping (uint => address[2]) public gameToPlayers;
     mapping (address => uint) ownerGameCount;
 
-    function createGame(address _player1, address _player2) public {
-        uint id = games.push(ChessGame(msg.sender, _player1, _player2, defaultPosition)) - 1;
+    function createGame(address _white, address _black) public {
+        uint id = games.push(ChessGame(msg.sender, _white, _black, true, defaultPosition)) - 1;
         gameToOwner[id] = msg.sender;
-        gameToPlayers[id] = [_player1, _player2];
+        gameToPlayers[id] = [_white, _black];
         ownerGameCount[msg.sender] = ownerGameCount[msg.sender].add(1);
-        emit NewGame(id, msg.sender, _player1, _player2);
+        emit NewGame(id, msg.sender, _white, _black);
     }
 }

--- a/contracts/gamefactory.sol
+++ b/contracts/gamefactory.sol
@@ -16,8 +16,8 @@ contract GameFactory is Ownable {
 
     struct ChessGame {
         address owner;
-        address player1;
-        address player2;
+        address white;
+        address black;
 
         string position;
     }

--- a/contracts/gamemodifiers.sol
+++ b/contracts/gamemodifiers.sol
@@ -15,4 +15,9 @@ contract GameModifiers is GameFactory {
         require(msg.sender == gameToPlayers[_gameId][0] || msg.sender == gameToPlayers[_gameId][1]);
         _;
     }
+
+    modifier onlyOracle(){
+        require(1==1); //Not sure how to make sure that an address is the oracle. Need to fix this later.
+        _;
+    }
 }

--- a/contracts/gamemodifiers.sol
+++ b/contracts/gamemodifiers.sol
@@ -12,7 +12,7 @@ contract GameModifiers is GameFactory {
     }
 
     modifier onlyPlayerOf(uint _gameId) {
-        require(msg.sender == gameToPlayers[_gameId][0] || msg.sender == gameToPlayers[_gameId][1]);
+        require(msg.sender == gameToPlayers[_gameId][games[_gameId].turn ? 1:0]); //ternary operator. 0 if false, 1 if true
         _;
     }
 

--- a/contracts/gamemove.sol
+++ b/contracts/gamemove.sol
@@ -7,7 +7,6 @@ contract GameMove is GameHelper {
     event requestMove(uint256 gameId, string gamePosition);
 
     function makeMove(uint256 _gameId, string calldata _position) external onlyPlayerOf(_gameId) {
-        //Todo: validate turns
         emit requestMove(_gameId, _position);
     }
 

--- a/contracts/gamemove.sol
+++ b/contracts/gamemove.sol
@@ -4,15 +4,14 @@ import "./gamehelper.sol";
 
 contract GameMove is GameHelper {
     event moveSuccessful(uint256 gameId, string gamePosition);
+    event requestMove(uint256 gameId, string gamePosition);
 
-    function move(uint256 _gameId) external onlyPlayerOf(_gameId) {
-        //leaving this blank until FEN parsing is implemented
+    function makeMove(uint256 _gameId, string calldata _position) external onlyPlayerOf(_gameId) {
+        //Todo: validate turns
+        emit requestMove(_gameId, _position);
     }
 
-    function setPosition(uint256 _gameId, string calldata _position)
-        external
-        onlyPlayerOf(_gameId)
-    {
+    function setPosition(uint256 _gameId, string calldata _position) external onlyOracle(){
         //No validation to make sure that the position is valid, or follows from a legal move of previous position, yet
         games[_gameId].position = _position;
         emit moveSuccessful(_gameId, _position);

--- a/test/ChessGame.js
+++ b/test/ChessGame.js
@@ -51,7 +51,7 @@ describe("ChessGame", function () {
                 //.withArgs(0, zombieNames[0], 8229335091878300);
             const x = await CGInstance.games(0);
             //console.log(x);
-            expect(x.player1).to.equal(alice.address);
+            expect(x.white).to.equal(alice.address);
         });
     });
 


### PR DESCRIPTION
A few relatively minor updates to the contracts:
* Renames variables for clarity
* Adds a bool to ChessGames that allows contracts to verify turns, verification is part of onlyPlayerOf modifier
* Implements architecture to allow oracle to be the one to actually change the board

I'm not sure how to verify the oracle when it updates the moves. Hopefully that should be the only thing left to do.